### PR TITLE
Fix data field for transaction

### DIFF
--- a/erdpy_network_providers/transactions.py
+++ b/erdpy_network_providers/transactions.py
@@ -78,7 +78,11 @@ class TransactionOnNetwork:
 
         result.gas_price = response.get('gasPrice', 0)
         result.gas_limit = response.get('gasLimit', 0)
-        result.data = base64.b64decode(response.get('data', '')).decode()
+
+        data = response.get('data', '')
+        data = "" if data is None else data
+
+        result.data = base64.b64decode(data).decode()
         result.status = TransactionStatus(response.get('status'))
         result.timestamp = response.get('timestamp', 0)
 

--- a/erdpy_network_providers/transactions.py
+++ b/erdpy_network_providers/transactions.py
@@ -79,8 +79,7 @@ class TransactionOnNetwork:
         result.gas_price = response.get('gasPrice', 0)
         result.gas_limit = response.get('gasLimit', 0)
 
-        data = response.get('data', '')
-        data = "" if data is None else data
+        data = response.get('data', '') or ""
 
         result.data = base64.b64decode(data).decode()
         result.status = TransactionStatus(response.get('status'))


### PR DESCRIPTION
Fixed the data field of `TransactionOnNetwork`.
The data field is a base64 string representation usually, but some transactions have a `null` data field. A check was needed to convert a `null` data field to an empty string (`""`) so it can be decoded instead of throwing an error.